### PR TITLE
Add extras to services and turnos

### DIFF
--- a/apiJMBROWS/LogicaAccesoDatos/EF/EsteticaContext.cs
+++ b/apiJMBROWS/LogicaAccesoDatos/EF/EsteticaContext.cs
@@ -15,6 +15,7 @@ namespace LogicaAccesoDatos.EF
         public DbSet<Turno> Turnos { get; set; }
         public DbSet<DetalleTurno> DetallesTurno { get; set; }
         public DbSet<PeriodoLaboral> PeriodosLaborales { get; set; }
+        public DbSet<ExtraServicio> ExtrasServicio { get; set; }
 
 
         public EsteticaContext(DbContextOptions<EsteticaContext> options) : base(options) { }
@@ -53,6 +54,12 @@ namespace LogicaAccesoDatos.EF
                 .HasMany(s => s.Habilidades)
                 .WithMany()
                 .UsingEntity(j => j.ToTable("HabilidadServicio"));
+
+            modelBuilder.Entity<Servicio>()
+                .HasMany(s => s.Extras)
+                .WithOne(e => e.Servicio)
+                .HasForeignKey(e => e.ServicioId)
+                .OnDelete(DeleteBehavior.Cascade);
 
 
 
@@ -95,6 +102,11 @@ namespace LogicaAccesoDatos.EF
                 .WithOne(d => d.Servicio)
                 .HasForeignKey(d => d.ServicioId)
                 .OnDelete(DeleteBehavior.Restrict);
+
+            modelBuilder.Entity<DetalleTurno>()
+                .HasMany(d => d.Extras)
+                .WithMany()
+                .UsingEntity(j => j.ToTable("DetalleTurnoExtra"));
             // Relación Empleado 1 - N PeriodoLaboral
             modelBuilder.Entity<PeriodoLaboral>()
                 .HasOne<Empleado>(p => p.Empleada)

--- a/apiJMBROWS/LogicaAccesoDatos/Repositorios/RepositorioDetalleTurno.cs
+++ b/apiJMBROWS/LogicaAccesoDatos/Repositorios/RepositorioDetalleTurno.cs
@@ -46,6 +46,7 @@ namespace LogicaAccesoDatos.Repositorios
         public DetalleTurno GetById(int id)
         {
             return _context.DetallesTurno
+                .Include(d => d.Extras)
                 .AsNoTracking()
                 .FirstOrDefault(d => d.Id == id);
         }
@@ -53,6 +54,7 @@ namespace LogicaAccesoDatos.Repositorios
         public IEnumerable<DetalleTurno> GetAll()
         {
             return _context.DetallesTurno
+                .Include(d => d.Extras)
                 .AsNoTracking()
                 .ToList();
         }

--- a/apiJMBROWS/LogicaAccesoDatos/Repositorios/RepositorioExtrasServicio.cs
+++ b/apiJMBROWS/LogicaAccesoDatos/Repositorios/RepositorioExtrasServicio.cs
@@ -1,0 +1,63 @@
+using LogicaAccesoDatos.EF;
+using LogicaNegocio.Entidades;
+using LogicaNegocio.InterfacesRepositorio;
+using Microsoft.EntityFrameworkCore;
+
+namespace LogicaAccesoDatos.Repositorios
+{
+    public class RepositorioExtrasServicio : IRepositorioExtrasServicio
+    {
+        private readonly EsteticaContext _context;
+
+        public RepositorioExtrasServicio(EsteticaContext context)
+        {
+            _context = context;
+        }
+
+        public void Add(ExtraServicio obj)
+        {
+            obj.EsValido();
+            _context.ExtrasServicio.Add(obj);
+            _context.SaveChanges();
+        }
+
+        public IEnumerable<ExtraServicio> GetAll()
+        {
+            return _context.ExtrasServicio.Include(e => e.Servicio).ToList();
+        }
+
+        public ExtraServicio GetById(int id)
+        {
+            return _context.ExtrasServicio.Include(e => e.Servicio).FirstOrDefault(e => e.Id == id);
+        }
+
+        public IEnumerable<ExtraServicio> ObtenerPorServicio(int servicioId)
+        {
+            return _context.ExtrasServicio.Where(e => e.ServicioId == servicioId).ToList();
+        }
+
+        public void Remove(int id)
+        {
+            var obj = _context.ExtrasServicio.Find(id);
+            if (obj != null)
+            {
+                _context.ExtrasServicio.Remove(obj);
+                _context.SaveChanges();
+            }
+        }
+
+        public void Remove(ExtraServicio obj)
+        {
+            _context.ExtrasServicio.Remove(obj);
+            _context.SaveChanges();
+        }
+
+        public void Update(int id, ExtraServicio obj)
+        {
+            var existente = _context.ExtrasServicio.Find(id);
+            if (existente == null) return;
+            _context.Entry(existente).CurrentValues.SetValues(obj);
+            _context.SaveChanges();
+        }
+    }
+}

--- a/apiJMBROWS/LogicaAccesoDatos/Repositorios/RepositorioServicios.cs
+++ b/apiJMBROWS/LogicaAccesoDatos/Repositorios/RepositorioServicios.cs
@@ -28,12 +28,16 @@ namespace LogicaAccesoDatos.EF
 
         public IEnumerable<Servicio> GetAll()
         {
-            return _context.Servicios.ToList();
+            return _context.Servicios
+                .Include(s => s.Extras)
+                .ToList();
         }
 
         public Servicio GetById(int id)
         {
-            return _context.Servicios.FirstOrDefault(s => s.Id == id);
+            return _context.Servicios
+                .Include(s => s.Extras)
+                .FirstOrDefault(s => s.Id == id);
         }
 
         public void Update(int id, Servicio obj)

--- a/apiJMBROWS/LogicaAccesoDatos/Repositorios/RepositorioTurnos.cs
+++ b/apiJMBROWS/LogicaAccesoDatos/Repositorios/RepositorioTurnos.cs
@@ -32,6 +32,7 @@ namespace LogicaAccesoDatos.EF
         {
             return _context.Turnos
                            .Include(t => t.Detalles)
+                               .ThenInclude(d => d.Extras)
                            .Include(t => t.Empleada)
                            .Include(t => t.Cliente)
                            .ToList();
@@ -41,6 +42,7 @@ namespace LogicaAccesoDatos.EF
         {
             return _context.Turnos
                            .Include(t => t.Detalles)
+                               .ThenInclude(d => d.Extras)
                            .Include(t => t.Empleada)
                            .Include(t => t.Cliente)
                            .FirstOrDefault(t => t.Id == id);
@@ -103,6 +105,7 @@ namespace LogicaAccesoDatos.EF
         {
             return _context.Turnos
                            .Include(t => t.Detalles)
+                               .ThenInclude(d => d.Extras)
                            .Include(t => t.Cliente)
                            .Where(t => t.EmpleadaId == empleadaId && !t.Cancelado)
                            .ToList();
@@ -113,6 +116,8 @@ namespace LogicaAccesoDatos.EF
             return _context.Turnos
                 .Include(t => t.Detalles)
                     .ThenInclude(d => d.Servicio)
+                .Include(t => t.Detalles)
+                    .ThenInclude(d => d.Extras)
                 .Include(t => t.Cliente)
                 .Where(t => t.EmpleadaId == empleadaId
                             && t.FechaHora.Date == dia.Date
@@ -125,6 +130,7 @@ namespace LogicaAccesoDatos.EF
         {
             return _context.Turnos
                            .Include(t => t.Detalles)
+                               .ThenInclude(d => d.Extras)
                            .Include(t => t.Cliente)
                            .Where(t => t.FechaHora.Date == dia.Date
                                        && !t.Cancelado
@@ -135,6 +141,8 @@ namespace LogicaAccesoDatos.EF
         public List<Turno> ObtenerParaFechaYEmpleado(DateTime fecha, int empleadaId)
         {
             return _context.Turnos
+                .Include(t => t.Detalles)
+                    .ThenInclude(d => d.Extras)
                 .Where(t => t.EmpleadaId == empleadaId && t.FechaHora.Date == fecha.Date && !t.Cancelado)
                 .ToList();
         }

--- a/apiJMBROWS/LogicaAplicacion/CasosDeUso/CUDetalleTurno/CUAltaDetalleTurno.cs
+++ b/apiJMBROWS/LogicaAplicacion/CasosDeUso/CUDetalleTurno/CUAltaDetalleTurno.cs
@@ -2,6 +2,7 @@ using LogicaAplicacion.Dtos.TurnoDTO;
 using LogicaAplicacion.InterfacesCasosDeUso.ICUDetalleTurno;
 using LogicaNegocio.Entidades;
 using LogicaNegocio.InterfacesRepositorio;
+using System.Linq;
 
 namespace LogicaAplicacion.CasosDeUso.CUDetalleTurno
 {
@@ -9,31 +10,34 @@ namespace LogicaAplicacion.CasosDeUso.CUDetalleTurno
     {
         private readonly IRepositorioTurnos _repoTurno;
         private readonly IRepositorioServicios _repoServicio;
+        private readonly IRepositorioExtrasServicio _repoExtras;
 
-        public CUAltaDetalleTurno(IRepositorioTurnos repoTurno, IRepositorioServicios repoServicio)
+        public CUAltaDetalleTurno(IRepositorioTurnos repoTurno, IRepositorioServicios repoServicio, IRepositorioExtrasServicio repoExtras)
         {
             _repoTurno = repoTurno;
             _repoServicio = repoServicio;
+            _repoExtras = repoExtras;
         }
 
         public void Ejecutar(AltaDetalleTurnoDTO dto)
         {
-            var turno = _repoTurno.GetById(dto.TurnoId);
-            if (turno == null) throw new Exception("Turno no encontrado.");
-
-            var servicio = _repoServicio.GetById(dto.ServicioId);
-            if (servicio == null) throw new Exception("Servicio no válido.");
+            var turno = _repoTurno.GetById(dto.TurnoId) ?? throw new Exception("Turno no encontrado.");
+            var servicio = _repoServicio.GetById(dto.ServicioId) ?? throw new Exception("Servicio no valido.");
 
             var nuevoDetalle = new DetalleTurno
             {
                 TurnoId = dto.TurnoId,
                 ServicioId = dto.ServicioId,
-
             };
 
+            if (dto.ExtrasIds != null && dto.ExtrasIds.Any())
+            {
+                var extras = _repoExtras.GetAll().Where(e => dto.ExtrasIds.Contains(e.Id)).ToList();
+                nuevoDetalle.Extras = extras;
+            }
+
             turno.Detalles.Add(nuevoDetalle);
-            _repoTurno.Update(dto.TurnoId, turno); // o método específico para agregar detalle si tenés
+            _repoTurno.Update(dto.TurnoId, turno);
         }
     }
-
 }

--- a/apiJMBROWS/LogicaAplicacion/CasosDeUso/CUExtraServicio/CUActualizarExtraServicio.cs
+++ b/apiJMBROWS/LogicaAplicacion/CasosDeUso/CUExtraServicio/CUActualizarExtraServicio.cs
@@ -1,0 +1,26 @@
+using LogicaAplicacion.Dtos.ExtraServicioDTO;
+using LogicaAplicacion.InterfacesCasosDeUso.ICUExtraServicio;
+using LogicaNegocio.InterfacesRepositorio;
+
+namespace LogicaAplicacion.CasosDeUso.CUExtraServicio
+{
+    public class CUActualizarExtraServicio : ICUActualizarExtraServicio
+    {
+        private readonly IRepositorioExtrasServicio _repo;
+
+        public CUActualizarExtraServicio(IRepositorioExtrasServicio repo)
+        {
+            _repo = repo;
+        }
+
+        public void Ejecutar(ExtraServicioDTO dto)
+        {
+            var extra = _repo.GetById(dto.Id);
+            if (extra == null) return;
+            extra.Nombre = dto.Nombre;
+            extra.DuracionMinutos = dto.DuracionMinutos;
+            extra.Precio = dto.Precio;
+            _repo.Update(dto.Id, extra);
+        }
+    }
+}

--- a/apiJMBROWS/LogicaAplicacion/CasosDeUso/CUExtraServicio/CUAltaExtraServicio.cs
+++ b/apiJMBROWS/LogicaAplicacion/CasosDeUso/CUExtraServicio/CUAltaExtraServicio.cs
@@ -1,0 +1,29 @@
+using LogicaAplicacion.Dtos.ExtraServicioDTO;
+using LogicaAplicacion.InterfacesCasosDeUso.ICUExtraServicio;
+using LogicaNegocio.Entidades;
+using LogicaNegocio.InterfacesRepositorio;
+
+namespace LogicaAplicacion.CasosDeUso.CUExtraServicio
+{
+    public class CUAltaExtraServicio : ICUAltaExtraServicio
+    {
+        private readonly IRepositorioExtrasServicio _repo;
+
+        public CUAltaExtraServicio(IRepositorioExtrasServicio repo)
+        {
+            _repo = repo;
+        }
+
+        public void Ejecutar(AltaExtraServicioDTO dto)
+        {
+            var extra = new ExtraServicio
+            {
+                Nombre = dto.Nombre,
+                DuracionMinutos = dto.DuracionMinutos,
+                Precio = dto.Precio,
+                ServicioId = dto.ServicioId
+            };
+            _repo.Add(extra);
+        }
+    }
+}

--- a/apiJMBROWS/LogicaAplicacion/CasosDeUso/CUExtraServicio/CUEliminarExtraServicio.cs
+++ b/apiJMBROWS/LogicaAplicacion/CasosDeUso/CUExtraServicio/CUEliminarExtraServicio.cs
@@ -1,0 +1,20 @@
+using LogicaAplicacion.InterfacesCasosDeUso.ICUExtraServicio;
+using LogicaNegocio.InterfacesRepositorio;
+
+namespace LogicaAplicacion.CasosDeUso.CUExtraServicio
+{
+    public class CUEliminarExtraServicio : ICUEliminarExtraServicio
+    {
+        private readonly IRepositorioExtrasServicio _repo;
+
+        public CUEliminarExtraServicio(IRepositorioExtrasServicio repo)
+        {
+            _repo = repo;
+        }
+
+        public void Ejecutar(int id)
+        {
+            _repo.Remove(id);
+        }
+    }
+}

--- a/apiJMBROWS/LogicaAplicacion/CasosDeUso/CUExtraServicio/CUObtenerExtraServicioPorId.cs
+++ b/apiJMBROWS/LogicaAplicacion/CasosDeUso/CUExtraServicio/CUObtenerExtraServicioPorId.cs
@@ -1,0 +1,30 @@
+using LogicaAplicacion.Dtos.ExtraServicioDTO;
+using LogicaAplicacion.InterfacesCasosDeUso.ICUExtraServicio;
+using LogicaNegocio.InterfacesRepositorio;
+
+namespace LogicaAplicacion.CasosDeUso.CUExtraServicio
+{
+    public class CUObtenerExtraServicioPorId : ICUObtenerExtraServicioPorId
+    {
+        private readonly IRepositorioExtrasServicio _repo;
+
+        public CUObtenerExtraServicioPorId(IRepositorioExtrasServicio repo)
+        {
+            _repo = repo;
+        }
+
+        public ExtraServicioDTO Ejecutar(int id)
+        {
+            var extra = _repo.GetById(id);
+            if (extra == null) return null;
+            return new ExtraServicioDTO
+            {
+                Id = extra.Id,
+                Nombre = extra.Nombre,
+                DuracionMinutos = extra.DuracionMinutos,
+                Precio = extra.Precio,
+                ServicioId = extra.ServicioId
+            };
+        }
+    }
+}

--- a/apiJMBROWS/LogicaAplicacion/CasosDeUso/CUExtraServicio/CUObtenerExtrasDeServicio.cs
+++ b/apiJMBROWS/LogicaAplicacion/CasosDeUso/CUExtraServicio/CUObtenerExtrasDeServicio.cs
@@ -1,0 +1,30 @@
+using LogicaAplicacion.Dtos.ExtraServicioDTO;
+using LogicaAplicacion.InterfacesCasosDeUso.ICUExtraServicio;
+using LogicaNegocio.InterfacesRepositorio;
+using System.Linq;
+
+namespace LogicaAplicacion.CasosDeUso.CUExtraServicio
+{
+    public class CUObtenerExtrasDeServicio : ICUObtenerExtrasDeServicio
+    {
+        private readonly IRepositorioExtrasServicio _repo;
+
+        public CUObtenerExtrasDeServicio(IRepositorioExtrasServicio repo)
+        {
+            _repo = repo;
+        }
+
+        public IEnumerable<ExtraServicioDTO> Ejecutar(int servicioId)
+        {
+            return _repo.ObtenerPorServicio(servicioId)
+                .Select(e => new ExtraServicioDTO
+                {
+                    Id = e.Id,
+                    Nombre = e.Nombre,
+                    DuracionMinutos = e.DuracionMinutos,
+                    Precio = e.Precio,
+                    ServicioId = e.ServicioId
+                });
+        }
+    }
+}

--- a/apiJMBROWS/LogicaAplicacion/Dtos/ExtraServicioDTO/AltaExtraServicioDTO.cs
+++ b/apiJMBROWS/LogicaAplicacion/Dtos/ExtraServicioDTO/AltaExtraServicioDTO.cs
@@ -1,0 +1,10 @@
+namespace LogicaAplicacion.Dtos.ExtraServicioDTO
+{
+    public class AltaExtraServicioDTO
+    {
+        public string Nombre { get; set; }
+        public int DuracionMinutos { get; set; }
+        public decimal Precio { get; set; }
+        public int ServicioId { get; set; }
+    }
+}

--- a/apiJMBROWS/LogicaAplicacion/Dtos/ExtraServicioDTO/ExtraServicioDTO.cs
+++ b/apiJMBROWS/LogicaAplicacion/Dtos/ExtraServicioDTO/ExtraServicioDTO.cs
@@ -1,0 +1,11 @@
+namespace LogicaAplicacion.Dtos.ExtraServicioDTO
+{
+    public class ExtraServicioDTO
+    {
+        public int Id { get; set; }
+        public string Nombre { get; set; }
+        public int DuracionMinutos { get; set; }
+        public decimal Precio { get; set; }
+        public int ServicioId { get; set; }
+    }
+}

--- a/apiJMBROWS/LogicaAplicacion/Dtos/TurnoDTO/AltaDetalleTurnoDTO.cs
+++ b/apiJMBROWS/LogicaAplicacion/Dtos/TurnoDTO/AltaDetalleTurnoDTO.cs
@@ -1,9 +1,11 @@
+using System.Collections.Generic;
+
 namespace LogicaAplicacion.Dtos.TurnoDTO
 {
     public class AltaDetalleTurnoDTO
     {
         public int TurnoId { get; set; }
         public int ServicioId { get; set; }
-
+        public List<int>? ExtrasIds { get; set; }
     }
 }

--- a/apiJMBROWS/LogicaAplicacion/InterfacesCasosDeUso/ICUExtraServicio/ICUActualizarExtraServicio.cs
+++ b/apiJMBROWS/LogicaAplicacion/InterfacesCasosDeUso/ICUExtraServicio/ICUActualizarExtraServicio.cs
@@ -1,0 +1,9 @@
+using LogicaAplicacion.Dtos.ExtraServicioDTO;
+
+namespace LogicaAplicacion.InterfacesCasosDeUso.ICUExtraServicio
+{
+    public interface ICUActualizarExtraServicio
+    {
+        void Ejecutar(ExtraServicioDTO dto);
+    }
+}

--- a/apiJMBROWS/LogicaAplicacion/InterfacesCasosDeUso/ICUExtraServicio/ICUAltaExtraServicio.cs
+++ b/apiJMBROWS/LogicaAplicacion/InterfacesCasosDeUso/ICUExtraServicio/ICUAltaExtraServicio.cs
@@ -1,0 +1,9 @@
+using LogicaAplicacion.Dtos.ExtraServicioDTO;
+
+namespace LogicaAplicacion.InterfacesCasosDeUso.ICUExtraServicio
+{
+    public interface ICUAltaExtraServicio
+    {
+        void Ejecutar(AltaExtraServicioDTO dto);
+    }
+}

--- a/apiJMBROWS/LogicaAplicacion/InterfacesCasosDeUso/ICUExtraServicio/ICUEliminarExtraServicio.cs
+++ b/apiJMBROWS/LogicaAplicacion/InterfacesCasosDeUso/ICUExtraServicio/ICUEliminarExtraServicio.cs
@@ -1,0 +1,7 @@
+namespace LogicaAplicacion.InterfacesCasosDeUso.ICUExtraServicio
+{
+    public interface ICUEliminarExtraServicio
+    {
+        void Ejecutar(int id);
+    }
+}

--- a/apiJMBROWS/LogicaAplicacion/InterfacesCasosDeUso/ICUExtraServicio/ICUObtenerExtraServicioPorId.cs
+++ b/apiJMBROWS/LogicaAplicacion/InterfacesCasosDeUso/ICUExtraServicio/ICUObtenerExtraServicioPorId.cs
@@ -1,0 +1,9 @@
+using LogicaAplicacion.Dtos.ExtraServicioDTO;
+
+namespace LogicaAplicacion.InterfacesCasosDeUso.ICUExtraServicio
+{
+    public interface ICUObtenerExtraServicioPorId
+    {
+        ExtraServicioDTO Ejecutar(int id);
+    }
+}

--- a/apiJMBROWS/LogicaAplicacion/InterfacesCasosDeUso/ICUExtraServicio/ICUObtenerExtrasDeServicio.cs
+++ b/apiJMBROWS/LogicaAplicacion/InterfacesCasosDeUso/ICUExtraServicio/ICUObtenerExtrasDeServicio.cs
@@ -1,0 +1,9 @@
+using LogicaAplicacion.Dtos.ExtraServicioDTO;
+
+namespace LogicaAplicacion.InterfacesCasosDeUso.ICUExtraServicio
+{
+    public interface ICUObtenerExtrasDeServicio
+    {
+        IEnumerable<ExtraServicioDTO> Ejecutar(int servicioId);
+    }
+}

--- a/apiJMBROWS/LogicaNegocio/Entidades/DetalleTurno.cs
+++ b/apiJMBROWS/LogicaNegocio/Entidades/DetalleTurno.cs
@@ -25,6 +25,8 @@ namespace LogicaNegocio.Entidades
 
         public Servicio? Servicio { get; set; }
 
+        public List<ExtraServicio> Extras { get; set; } = new();
+
         [NotMapped]
         public DateTime HoraInicio { get; set; }
         [NotMapped]

--- a/apiJMBROWS/LogicaNegocio/Entidades/ExtraServicio.cs
+++ b/apiJMBROWS/LogicaNegocio/Entidades/ExtraServicio.cs
@@ -1,0 +1,33 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace LogicaNegocio.Entidades
+{
+    public class ExtraServicio
+    {
+        [Key]
+        public int Id { get; set; }
+
+        [Required]
+        [MinLength(3)]
+        public required string Nombre { get; set; }
+
+        [Range(1, 240)]
+        public int DuracionMinutos { get; set; }
+
+        [Range(0.0, 10000.0)]
+        public decimal Precio { get; set; }
+
+        public int ServicioId { get; set; }
+        public Servicio? Servicio { get; set; }
+
+        public void EsValido()
+        {
+            if (string.IsNullOrWhiteSpace(Nombre) || Nombre.Length < 3)
+                throw new Exception("El nombre del extra debe tener al menos 3 caracteres.");
+            if (DuracionMinutos <= 0)
+                throw new Exception("La duracion debe ser positiva.");
+            if (Precio < 0)
+                throw new Exception("El precio no puede ser negativo.");
+        }
+    }
+}

--- a/apiJMBROWS/LogicaNegocio/Entidades/Servicio.cs
+++ b/apiJMBROWS/LogicaNegocio/Entidades/Servicio.cs
@@ -26,6 +26,8 @@ public class Servicio
     // Relación solo con Habilidades (si la usás)
     public List<Habilidad> Habilidades { get; set; } = new();
 
+    public List<ExtraServicio> Extras { get; set; } = new();
+
 
     public void EsValido()
     {

--- a/apiJMBROWS/LogicaNegocio/Entidades/Turno.cs
+++ b/apiJMBROWS/LogicaNegocio/Entidades/Turno.cs
@@ -56,7 +56,8 @@ namespace LogicaNegocio.Entidades
             foreach (var detalle in Detalles.OrderBy(d => d.Id)) // O el orden que corresponda
             {
                 detalle.HoraInicio = horaActual;
-                detalle.HoraFin = horaActual.AddMinutes(detalle.Servicio.DuracionMinutos);
+                var extraDuracion = detalle.Extras.Sum(e => e.DuracionMinutos);
+                detalle.HoraFin = horaActual.AddMinutes(detalle.Servicio.DuracionMinutos + extraDuracion);
                 horaActual = detalle.HoraFin;
             }
 
@@ -70,13 +71,15 @@ namespace LogicaNegocio.Entidades
         public int DuracionTotal()
         {
             // Suma la duración de todos los servicios de los detalles del turno
-            return Detalles.Sum(d => d.Servicio?.DuracionMinutos ?? 0);
+            return Detalles.Sum(d =>
+                (d.Servicio?.DuracionMinutos ?? 0) + d.Extras.Sum(e => e.DuracionMinutos));
         }
 
         public decimal PrecioTotal()
         {
             // Suma el precio de todos los servicios de los detalles del turno
-            return Detalles.Sum(d => d.Servicio?.Precio ?? 0);
+            return Detalles.Sum(d =>
+                (d.Servicio?.Precio ?? 0) + d.Extras.Sum(e => e.Precio));
         }
 
         public void AgregarDetalle(DetalleTurno detalle)

--- a/apiJMBROWS/LogicaNegocio/InterfacesRepositorio/IRepositorioExtrasServicio.cs
+++ b/apiJMBROWS/LogicaNegocio/InterfacesRepositorio/IRepositorioExtrasServicio.cs
@@ -1,0 +1,10 @@
+using Libreria.LogicaNegocio.InterfacesRepositorio;
+using LogicaNegocio.Entidades;
+
+namespace LogicaNegocio.InterfacesRepositorio
+{
+    public interface IRepositorioExtrasServicio : IRepositorio<ExtraServicio>
+    {
+        IEnumerable<ExtraServicio> ObtenerPorServicio(int servicioId);
+    }
+}

--- a/apiJMBROWS/apiJMBROWS/Controllers/ServicioController.cs
+++ b/apiJMBROWS/apiJMBROWS/Controllers/ServicioController.cs
@@ -1,7 +1,9 @@
 ﻿using LogicaAplicacion.Dtos.HabilidadDTO;
 using LogicaAplicacion.Dtos.SectorDTO;
 using LogicaAplicacion.Dtos.ServicioDTO;
+using LogicaAplicacion.Dtos.ExtraServicioDTO;
 using LogicaAplicacion.InterfacesCasosDeUso.ICUServicio;
+using LogicaAplicacion.InterfacesCasosDeUso.ICUExtraServicio;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
@@ -25,6 +27,11 @@ namespace apiJMBROWS.Controllers
         private readonly ICUQuitarHabilidadDeServicio _quitarHabilidad;
         private readonly ICUObtenerHabilidadesServicio _obtenerHabilidadesServicio;
         private readonly ICUObtenerSectoresServicio _obtenerSectoresServicio;
+        private readonly ICUAltaExtraServicio _altaExtra;
+        private readonly ICUActualizarExtraServicio _actualizarExtra;
+        private readonly ICUEliminarExtraServicio _eliminarExtra;
+        private readonly ICUObtenerExtrasDeServicio _obtenerExtras;
+        private readonly ICUObtenerExtraServicioPorId _obtenerExtraPorId;
         public ServicioController(
             ICUAltaServicio altaServicio,
             ICUActualizarServicio actualizarServicio,
@@ -37,7 +44,12 @@ namespace apiJMBROWS.Controllers
             ICUAsignarHabilidadAServicio asignarHabilidad,
             ICUQuitarHabilidadDeServicio quitarHabilidad,
             ICUObtenerHabilidadesServicio obtenerHabilidadesServicio,
-            ICUObtenerSectoresServicio obtenerSectoresServicio)
+            ICUObtenerSectoresServicio obtenerSectoresServicio,
+            ICUAltaExtraServicio altaExtra,
+            ICUActualizarExtraServicio actualizarExtra,
+            ICUEliminarExtraServicio eliminarExtra,
+            ICUObtenerExtrasDeServicio obtenerExtras,
+            ICUObtenerExtraServicioPorId obtenerExtraPorId)
         {
             _altaServicio = altaServicio;
             _actualizarServicio = actualizarServicio;
@@ -51,6 +63,11 @@ namespace apiJMBROWS.Controllers
             _quitarHabilidad = quitarHabilidad;
             _obtenerHabilidadesServicio = obtenerHabilidadesServicio;
             _obtenerSectoresServicio = obtenerSectoresServicio;
+            _altaExtra = altaExtra;
+            _actualizarExtra = actualizarExtra;
+            _eliminarExtra = eliminarExtra;
+            _obtenerExtras = obtenerExtras;
+            _obtenerExtraPorId = obtenerExtraPorId;
         }
 
         /// <summary>
@@ -305,6 +322,49 @@ namespace apiJMBROWS.Controllers
             {
                 return NotFound(new { error = e.Message });
             }
+        }
+
+        [HttpGet("{servicioId}/extras")]
+        [AllowAnonymous]
+        public IActionResult GetExtras(int servicioId)
+        {
+            var extras = _obtenerExtras.Ejecutar(servicioId);
+            return Ok(extras);
+        }
+
+        [HttpGet("extras/{id}")]
+        [AllowAnonymous]
+        public IActionResult GetExtra(int id)
+        {
+            var extra = _obtenerExtraPorId.Ejecutar(id);
+            if (extra == null) return NotFound();
+            return Ok(extra);
+        }
+
+        [HttpPost("{servicioId}/extras")]
+        [Authorize(Roles = "Administrador")]
+        public IActionResult CrearExtra(int servicioId, [FromBody] AltaExtraServicioDTO dto)
+        {
+            dto.ServicioId = servicioId;
+            _altaExtra.Ejecutar(dto);
+            return Ok();
+        }
+
+        [HttpPut("extras/{id}")]
+        [Authorize(Roles = "Administrador")]
+        public IActionResult ActualizarExtra(int id, [FromBody] ExtraServicioDTO dto)
+        {
+            if (id != dto.Id) return BadRequest();
+            _actualizarExtra.Ejecutar(dto);
+            return Ok();
+        }
+
+        [HttpDelete("extras/{id}")]
+        [Authorize(Roles = "Administrador")]
+        public IActionResult EliminarExtra(int id)
+        {
+            _eliminarExtra.Ejecutar(id);
+            return Ok();
         }
 
 

--- a/apiJMBROWS/apiJMBROWS/Program.cs
+++ b/apiJMBROWS/apiJMBROWS/Program.cs
@@ -8,6 +8,7 @@ using LogicaAplicacion.CasosDeUso.CUEmpleado;
 using LogicaAplicacion.CasosDeUso.CUHabilidad;
 using LogicaAplicacion.CasosDeUso.CUPeriodoLaboral;
 using LogicaAplicacion.CasosDeUso.CUServicio;
+using LogicaAplicacion.CasosDeUso.CUExtraServicio;
 using LogicaAplicacion.CasosDeUso.CUSucursal;
 using LogicaAplicacion.CasosDeUso.CUTurno;
 using LogicaAplicacion.InterfacesCasosDeUso;
@@ -18,6 +19,7 @@ using LogicaAplicacion.InterfacesCasosDeUso.ICUHabilidad;
 using LogicaAplicacion.InterfacesCasosDeUso.ICUPeriodoLaboral;
 using LogicaAplicacion.InterfacesCasosDeUso.ICUSector;
 using LogicaAplicacion.InterfacesCasosDeUso.ICUServicio;
+using LogicaAplicacion.InterfacesCasosDeUso.ICUExtraServicio;
 using LogicaAplicacion.InterfacesCasosDeUso.ICUSurcursal;
 using LogicaAplicacion.InterfacesCasosDeUso.ICUTurno;
 using LogicaNegocio.Excepciones.Middleware;
@@ -47,6 +49,7 @@ namespace apiJMBROWS
             builder.Services.AddScoped<IRepositorioUsuarios, RepositorioUsuarios>();
             builder.Services.AddScoped<IRepositorioSucursales, RepositorioSucursales>();
             builder.Services.AddScoped<IRepositorioServicios, RepositorioServicios>();
+            builder.Services.AddScoped<IRepositorioExtrasServicio, RepositorioExtrasServicio>();
             builder.Services.AddScoped<IRepositorioHabilidades, RepositorioHabilidades>();
             builder.Services.AddScoped<IRepositorioTurnos, RepositorioTurnos>();
             builder.Services.AddScoped<IRepositorioClientes, RepositorioClientes>();
@@ -82,6 +85,11 @@ namespace apiJMBROWS
             builder.Services.AddScoped<ICUQuitarHabilidadDeServicio, CUQuitarHabilidadDeServicio>();
             builder.Services.AddScoped<ICUObtenerSectoresServicio, CUObtenerSectoresServicio>();
             builder.Services.AddScoped<ICUObtenerHabilidadesServicio, CUObtenerHabilidadesServicio>();
+            builder.Services.AddScoped<ICUAltaExtraServicio, CUAltaExtraServicio>();
+            builder.Services.AddScoped<ICUObtenerExtrasDeServicio, CUObtenerExtrasDeServicio>();
+            builder.Services.AddScoped<ICUActualizarExtraServicio, CUActualizarExtraServicio>();
+            builder.Services.AddScoped<ICUEliminarExtraServicio, CUEliminarExtraServicio>();
+            builder.Services.AddScoped<ICUObtenerExtraServicioPorId, CUObtenerExtraServicioPorId>();
 
             builder.Services.AddScoped<ICUAltaHabilidad, CUAltaHabilidad>();
             builder.Services.AddScoped<ICUActualizarHabilidad, CUActualizarHabilidad>();


### PR DESCRIPTION
## Summary
- add new `ExtraServicio` entity and integrate with `Servicio`
- allow detalles de turno to include extras
- update duration/price calculations in `Turno`
- create repository and use cases for extras
- expose CRUD API endpoints for extras within `ServicioController`
- register new services in dependency injection

## Testing
- `dotnet ef migrations add ExtraServicio` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685ec9ec71d48324a501bfacd9b85451