### PR TITLE
Implementa horarios por empleada

### DIFF
--- a/apiJMBROWS/LogicaAplicacion/CasosDeUso/CUTurno/CUObtenerHorariosPorEmpleada.cs
+++ b/apiJMBROWS/LogicaAplicacion/CasosDeUso/CUTurno/CUObtenerHorariosPorEmpleada.cs
@@ -1,0 +1,113 @@
+using LogicaAplicacion.Dtos.TurnoDTO;
+using LogicaAplicacion.InterfacesCasosDeUso.ICUTurno;
+using LogicaNegocio.Entidades;
+using LogicaNegocio.Entidades.Enums;
+using LogicaNegocio.InterfacesRepositorio;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace LogicaAplicacion.CasosDeUso.CUTurno
+{
+    public class CUObtenerHorariosPorEmpleada : ICUObtenerHorariosPorEmpleada
+    {
+        private readonly IRepositorioTurnos _repoTurno;
+        private readonly IRepositorioUsuarios _repoEmpleado;
+        private readonly IRepositorioServicios _repoServicio;
+
+        public CUObtenerHorariosPorEmpleada(IRepositorioTurnos repoTurno,
+                                             IRepositorioUsuarios repoEmpleado,
+                                             IRepositorioServicios repoServicio)
+        {
+            _repoTurno = repoTurno;
+            _repoEmpleado = repoEmpleado;
+            _repoServicio = repoServicio;
+        }
+
+        public List<HorarioDisponibleDTO> Ejecutar(HorariosPorEmpleadaFiltroDTO filtro)
+        {
+            var empleada = _repoEmpleado.GetEmpleadoById(filtro.EmpleadaId);
+            if (empleada == null)
+                return new List<HorarioDisponibleDTO>();
+
+            var servicios = _repoServicio.ObtenerPorIds(filtro.ServicioIds);
+            int duracionTotal = servicios.Sum(s => s.DuracionMinutos);
+
+            var habilidadesNecesarias = servicios
+                .SelectMany(s => s.Habilidades)
+                .Select(h => h.Id)
+                .Distinct()
+                .ToList();
+
+            bool empleadaValida = empleada.SectoresAsignados.Any(s => s.SucursalId == filtro.SucursalId) &&
+                                   habilidadesNecesarias.All(h => empleada.Habilidades.Any(eh => eh.Id == h));
+            if (!empleadaValida)
+                return new List<HorarioDisponibleDTO>();
+
+            var periodos = empleada.PeriodosLaborales
+                .Where(p => p.Tipo == TipoPeriodoLaboral.HorarioHabitual &&
+                            p.DiaSemana == filtro.Fecha.DayOfWeek &&
+                            p.HoraInicio.HasValue &&
+                            p.HoraFin.HasValue)
+                .ToList();
+
+            var turnos = _repoTurno.ObtenerTurnosDelDiaPorEmpleada(empleada.Id, filtro.Fecha);
+
+            var horarios = new List<HorarioDisponibleDTO>();
+
+            foreach (var p in periodos)
+            {
+                var bloques = GenerarBloques(p.HoraInicio.Value, p.HoraFin.Value, filtro.Fecha, duracionTotal);
+
+                foreach (var bloque in bloques)
+                {
+                    bool ocupado = turnos.Any(t =>
+                        bloque.inicio < t.FechaHora.AddMinutes(t.DuracionTotal()) &&
+                        bloque.fin > t.FechaHora);
+
+                    bool enLicencia = empleada.PeriodosLaborales.Any(l =>
+                        l.Tipo == TipoPeriodoLaboral.Licencia &&
+                        l.Desde <= bloque.inicio &&
+                        l.Hasta >= bloque.fin);
+
+                    if (!ocupado && !enLicencia)
+                    {
+                        horarios.Add(new HorarioDisponibleDTO
+                        {
+                            FechaHoraInicio = bloque.inicio,
+                            FechaHoraFin = bloque.fin,
+                            EmpleadasDisponibles = new List<EmpleadoTurnoDTO>
+                            {
+                                new EmpleadoTurnoDTO
+                                {
+                                    Id = empleada.Id,
+                                    Nombre = empleada.Nombre,
+                                    Apellido = empleada.Apellido,
+                                    Email = empleada.Email,
+                                    Cargo = empleada.Cargo
+                                }
+                            }
+                        });
+                    }
+                }
+            }
+
+            return horarios;
+        }
+
+        private List<(DateTime inicio, DateTime fin)> GenerarBloques(TimeSpan desde, TimeSpan hasta, DateTime fecha, int duracionMinutos)
+        {
+            var bloques = new List<(DateTime, DateTime)>();
+            var actual = fecha.Date + desde;
+            var fin = fecha.Date + hasta;
+
+            while (actual.AddMinutes(duracionMinutos) <= fin)
+            {
+                bloques.Add((actual, actual.AddMinutes(duracionMinutos)));
+                actual = actual.AddMinutes(15);
+            }
+
+            return bloques;
+        }
+    }
+}

--- a/apiJMBROWS/LogicaAplicacion/Dtos/TurnoDTO/HorariosPorEmpleadaFiltroDTO.cs
+++ b/apiJMBROWS/LogicaAplicacion/Dtos/TurnoDTO/HorariosPorEmpleadaFiltroDTO.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+
+namespace LogicaAplicacion.Dtos.TurnoDTO
+{
+    public class HorariosPorEmpleadaFiltroDTO
+    {
+        public int EmpleadaId { get; set; }
+        public int SucursalId { get; set; }
+        public DateTime Fecha { get; set; }
+        public List<int> ServicioIds { get; set; } = new();
+    }
+}

--- a/apiJMBROWS/LogicaAplicacion/InterfacesCasosDeUso/ICUTurno/ICUObtenerHorariosPorEmpleada.cs
+++ b/apiJMBROWS/LogicaAplicacion/InterfacesCasosDeUso/ICUTurno/ICUObtenerHorariosPorEmpleada.cs
@@ -1,0 +1,10 @@
+using LogicaAplicacion.Dtos.TurnoDTO;
+using System.Collections.Generic;
+
+namespace LogicaAplicacion.InterfacesCasosDeUso.ICUTurno
+{
+    public interface ICUObtenerHorariosPorEmpleada
+    {
+        List<HorarioDisponibleDTO> Ejecutar(HorariosPorEmpleadaFiltroDTO filtro);
+    }
+}

--- a/apiJMBROWS/apiJMBROWS/Controllers/TurnoController.cs
+++ b/apiJMBROWS/apiJMBROWS/Controllers/TurnoController.cs
@@ -27,6 +27,7 @@ namespace apiJMBROWS.Controllers
         private readonly ICUObtenerDetalleTurnoPorId _obtenerDetalleTurnoPorId;
         private readonly ICUEliminarDetalleTurno _eliminarDetalleTurno;
         private readonly ICUObtenerHorariosDisponibles _horariosDisponibles;
+        private readonly ICUObtenerHorariosPorEmpleada _horariosPorEmpleada;
         public TurnosController(
             ICUAltaTurno altaTurno,
             ICUObtenerTurnos obtenerTurnos,
@@ -39,8 +40,9 @@ namespace apiJMBROWS.Controllers
             ICUObtenerDetallesTurno obtenerDetallesTurno,
             ICUActualizarDetalleTurno actualizarDetalleTurno,
             ICUObtenerDetalleTurnoPorId obtenerDetalleTurnoPorId,
-            ICUEliminarDetalleTurno eliminarDetalleTurno, 
-            ICUObtenerHorariosDisponibles horariosDisponibles
+            ICUEliminarDetalleTurno eliminarDetalleTurno,
+            ICUObtenerHorariosDisponibles horariosDisponibles,
+            ICUObtenerHorariosPorEmpleada horariosPorEmpleada
             )
         {
             _altaTurno = altaTurno;
@@ -56,6 +58,7 @@ namespace apiJMBROWS.Controllers
             _obtenerDetalleTurnoPorId = obtenerDetalleTurnoPorId;
             _eliminarDetalleTurno = eliminarDetalleTurno;
             _horariosDisponibles = horariosDisponibles;
+            _horariosPorEmpleada = horariosPorEmpleada;
         }
 
         /// <summary>
@@ -277,6 +280,29 @@ namespace apiJMBROWS.Controllers
 
                 var horarios = _horariosDisponibles.Ejecutar(filtro);
 
+                return Ok(horarios);
+            }
+            catch (Exception ex)
+            {
+                return StatusCode(500, $"Error al obtener horarios: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Obtiene los horarios disponibles para una empleada seleccionada
+        /// </summary>
+        [HttpPost("horarios-disponibles-empleada")]
+        [AllowAnonymous]
+        [SwaggerOperation(Summary = "Horarios disponibles de una empleada")]
+        [SwaggerResponse(200, "Lista de horarios disponibles", typeof(List<HorarioDisponibleDTO>))]
+        public ActionResult<List<HorarioDisponibleDTO>> ObtenerHorariosPorEmpleada([FromBody] HorariosPorEmpleadaFiltroDTO filtro)
+        {
+            try
+            {
+                if (filtro.ServicioIds == null || !filtro.ServicioIds.Any())
+                    return BadRequest("Debe seleccionar al menos un servicio.");
+
+                var horarios = _horariosPorEmpleada.Ejecutar(filtro);
                 return Ok(horarios);
             }
             catch (Exception ex)

--- a/apiJMBROWS/apiJMBROWS/Program.cs
+++ b/apiJMBROWS/apiJMBROWS/Program.cs
@@ -124,6 +124,7 @@ namespace apiJMBROWS
             builder.Services.AddScoped<ICUObtenerTurnosPorEmpleada, CUObtenerTurnosPorEmpleada>();
             builder.Services.AddScoped<ICUObtenerTurnosDelDiaPorEmpleada, CUObtenerTurnosDelDiaPorEmpleada>();
             builder.Services.AddScoped<ICUObtenerHorariosDisponibles, CUObtenerHorariosDisponibles>();
+            builder.Services.AddScoped<ICUObtenerHorariosPorEmpleada, CUObtenerHorariosPorEmpleada>();
 
             builder.Services.AddScoped<ICUAltaDetalleTurno, CUAltaDetalleTurno>();
             builder.Services.AddScoped<ICUActualizarDetalleTurno, CUActualizarDetalleTurno>();


### PR DESCRIPTION
## Summary
- añade `HorariosPorEmpleadaFiltroDTO` y su interfaz de caso de uso
- implementa `CUObtenerHorariosPorEmpleada`
- expone un nuevo endpoint en `TurnosController` para consultar horarios de una empleada
- registra el nuevo caso de uso en `Program`

## Testing
- `dotnet build --no-restore` *(falló: `bash: dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68652851b74083249465eced7edcb7bf