### PR TITLE
Refactor turno status with enum

### DIFF
--- a/apiJMBROWS/LogicaAccesoDatos/Migrations/EsteticaContextModelSnapshot.cs
+++ b/apiJMBROWS/LogicaAccesoDatos/Migrations/EsteticaContextModelSnapshot.cs
@@ -382,8 +382,8 @@ namespace LogicaAccesoDatos.Migrations
 
                     SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
 
-                    b.Property<bool>("Cancelado")
-                        .HasColumnType("bit");
+                    b.Property<int>("Estado")
+                        .HasColumnType("int");
 
                     b.Property<int>("ClienteId")
                         .HasColumnType("int");
@@ -394,8 +394,6 @@ namespace LogicaAccesoDatos.Migrations
                     b.Property<DateTime>("FechaHora")
                         .HasColumnType("datetime2");
 
-                    b.Property<bool>("Realizado")
-                        .HasColumnType("bit");
 
                     b.Property<int?>("SectorId")
                         .HasColumnType("int");

--- a/apiJMBROWS/LogicaAccesoDatos/Repositorios/RepositorioTurnos.cs
+++ b/apiJMBROWS/LogicaAccesoDatos/Repositorios/RepositorioTurnos.cs
@@ -1,5 +1,6 @@
 ﻿using LogicaNegocio.Entidades;
 using LogicaNegocio.InterfacesRepositorio;
+using LogicaNegocio.Entidades.Enums;
 using Microsoft.EntityFrameworkCore;
 using System;
 using System.Collections.Generic;
@@ -107,7 +108,7 @@ namespace LogicaAccesoDatos.EF
                            .Include(t => t.Detalles)
                                .ThenInclude(d => d.Extras)
                            .Include(t => t.Cliente)
-                           .Where(t => t.EmpleadaId == empleadaId && !t.Cancelado)
+                           .Where(t => t.EmpleadaId == empleadaId && t.Estado != EstadoTurno.Cancelado)
                            .ToList();
         }
 
@@ -121,8 +122,7 @@ namespace LogicaAccesoDatos.EF
                 .Include(t => t.Cliente)
                 .Where(t => t.EmpleadaId == empleadaId
                             && t.FechaHora.Date == dia.Date
-                            && !t.Cancelado
-                            && !t.Realizado)
+                            && t.Estado == EstadoTurno.Pendiente)
                 .ToList();
         }
 
@@ -133,8 +133,7 @@ namespace LogicaAccesoDatos.EF
                                .ThenInclude(d => d.Extras)
                            .Include(t => t.Cliente)
                            .Where(t => t.FechaHora.Date == dia.Date
-                                       && !t.Cancelado
-                                       && !t.Realizado)
+                                       && t.Estado == EstadoTurno.Pendiente)
                            .ToList();
         }
 
@@ -143,7 +142,7 @@ namespace LogicaAccesoDatos.EF
             return _context.Turnos
                 .Include(t => t.Detalles)
                     .ThenInclude(d => d.Extras)
-                .Where(t => t.EmpleadaId == empleadaId && t.FechaHora.Date == fecha.Date && !t.Cancelado)
+                .Where(t => t.EmpleadaId == empleadaId && t.FechaHora.Date == fecha.Date && t.Estado != EstadoTurno.Cancelado)
                 .ToList();
         }
 

--- a/apiJMBROWS/LogicaAplicacion/CasosDeUso/CUReportes/CUEstadoTurnos.cs
+++ b/apiJMBROWS/LogicaAplicacion/CasosDeUso/CUReportes/CUEstadoTurnos.cs
@@ -3,6 +3,7 @@ using LogicaAplicacion.InterfacesCasosDeUso.ICUReportes;
 using LogicaNegocio.InterfacesRepositorio;
 using System.Linq;
 
+using LogicaNegocio.Entidades.Enums;
 namespace LogicaAplicacion.CasosDeUso.CUReportes
 {
     public class CUEstadoTurnos : ICUEstadoTurnos
@@ -20,8 +21,8 @@ namespace LogicaAplicacion.CasosDeUso.CUReportes
                 .Where(t => t.FechaHora.Year == anio && t.FechaHora.Month == mes);
             return new EstadoTurnosDTO
             {
-                Realizados = turnos.Count(t => t.Realizado && !t.Cancelado),
-                Cancelados = turnos.Count(t => t.Cancelado)
+                Realizados = turnos.Count(t => t.Estado == EstadoTurno.Realizado),
+                Cancelados = turnos.Count(t => t.Estado == EstadoTurno.Cancelado)
             };
         }
     }

--- a/apiJMBROWS/LogicaAplicacion/CasosDeUso/CUReportes/CUHorarioMayorTurnos.cs
+++ b/apiJMBROWS/LogicaAplicacion/CasosDeUso/CUReportes/CUHorarioMayorTurnos.cs
@@ -3,6 +3,7 @@ using LogicaAplicacion.InterfacesCasosDeUso.ICUReportes;
 using LogicaNegocio.InterfacesRepositorio;
 using System.Linq;
 
+using LogicaNegocio.Entidades.Enums;
 namespace LogicaAplicacion.CasosDeUso.CUReportes
 {
     public class CUHorarioMayorTurnos : ICUHorarioMayorTurnos
@@ -17,7 +18,7 @@ namespace LogicaAplicacion.CasosDeUso.CUReportes
         public HorarioMayorTurnosDTO Ejecutar(int anio, int mes)
         {
             var turnos = _repoTurnos.GetAll()
-                .Where(t => t.FechaHora.Year == anio && t.FechaHora.Month == mes && !t.Cancelado);
+                .Where(t => t.FechaHora.Year == anio && t.FechaHora.Month == mes && t.Estado != EstadoTurno.Cancelado);
             var grupo = turnos
                 .GroupBy(t => t.FechaHora.Hour)
                 .Select(g => new { Hora = g.Key, Cantidad = g.Count() })

--- a/apiJMBROWS/LogicaAplicacion/CasosDeUso/CUReportes/CUIngresosSucursalSector.cs
+++ b/apiJMBROWS/LogicaAplicacion/CasosDeUso/CUReportes/CUIngresosSucursalSector.cs
@@ -4,6 +4,7 @@ using LogicaNegocio.InterfacesRepositorio;
 using System.Collections.Generic;
 using System.Linq;
 
+using LogicaNegocio.Entidades.Enums;
 namespace LogicaAplicacion.CasosDeUso.CUReportes
 {
     public class CUIngresosSucursalSector : ICUIngresosSucursalSector
@@ -27,7 +28,7 @@ namespace LogicaAplicacion.CasosDeUso.CUReportes
                 .ToDictionary(s => s.Id, s => s.Nombre.ToLower());
             var turnos = _repoTurnos.GetAll()
                 .Where(t => t.FechaHora.Year == anio && t.FechaHora.Month == mes &&
-                            t.Realizado && !t.Cancelado);
+                            t.Estado == EstadoTurno.Realizado);
             var sucursales = _repoSucursales.GetAll();
             var lista = new List<IngresosSucursalDTO>();
 

--- a/apiJMBROWS/LogicaAplicacion/CasosDeUso/CUReportes/CUTurnosPorServicio.cs
+++ b/apiJMBROWS/LogicaAplicacion/CasosDeUso/CUReportes/CUTurnosPorServicio.cs
@@ -4,6 +4,7 @@ using LogicaNegocio.InterfacesRepositorio;
 using System.Collections.Generic;
 using System.Linq;
 
+using LogicaNegocio.Entidades.Enums;
 namespace LogicaAplicacion.CasosDeUso.CUReportes
 {
     public class CUTurnosPorServicio : ICUTurnosPorServicio
@@ -22,7 +23,7 @@ namespace LogicaAplicacion.CasosDeUso.CUReportes
             var servicios = _repoServicios.GetAll().ToDictionary(s => s.Id, s => s.Nombre);
             var conteo = new Dictionary<int, int>();
             var turnos = _repoTurnos.GetAll()
-                .Where(t => t.FechaHora.Year == anio && t.FechaHora.Month == mes && !t.Cancelado);
+                .Where(t => t.FechaHora.Year == anio && t.FechaHora.Month == mes && t.Estado != EstadoTurno.Cancelado);
 
             foreach (var t in turnos)
             {

--- a/apiJMBROWS/LogicaAplicacion/CasosDeUso/CUTurno/CUActualizarTurno.cs
+++ b/apiJMBROWS/LogicaAplicacion/CasosDeUso/CUTurno/CUActualizarTurno.cs
@@ -3,6 +3,7 @@ using LogicaAplicacion.InterfacesCasosDeUso.ICUTurno;
 using LogicaNegocio.InterfacesRepositorio;
 using LogicaNegocio.Entidades;
 using System;
+using LogicaNegocio.Entidades.Enums;
 using System.Linq;
 
 namespace LogicaAplicacion.CasosDeUso.CUTurno
@@ -25,7 +26,7 @@ namespace LogicaAplicacion.CasosDeUso.CUTurno
             turno.FechaHora = dto.FechaHora;
             turno.EmpleadaId = dto.EmpleadaId;
             turno.ClienteId = dto.ClienteId;
-            turno.Realizado = dto.Realizado;
+            turno.Estado = dto.Estado;
             turno.SucursalId = dto.SucursalId;
             turno.SectorId = dto.SectorId;
 
@@ -39,7 +40,7 @@ namespace LogicaAplicacion.CasosDeUso.CUTurno
                 });
             }
 
-            turno.EsValido(); // <-- Validación de solapamiento
+            turno.EsValido(); // <-- ValidaciÃ³n de solapamiento
 
             _repo.Update(dto.Id, turno);
         }

--- a/apiJMBROWS/LogicaAplicacion/CasosDeUso/CUTurno/CUObtenerTurnoPorId.cs
+++ b/apiJMBROWS/LogicaAplicacion/CasosDeUso/CUTurno/CUObtenerTurnoPorId.cs
@@ -3,6 +3,7 @@ using LogicaAplicacion.InterfacesCasosDeUso.ICUTurno;
 using LogicaNegocio.InterfacesRepositorio;
 using System.Linq;
 
+using LogicaNegocio.Entidades.Enums;
 namespace LogicaAplicacion.CasosDeUso.CUTurno
 {
     public class CUObtenerTurnoPorId : ICUObtenerTurnoPorId
@@ -25,7 +26,7 @@ namespace LogicaAplicacion.CasosDeUso.CUTurno
                 FechaHora = t.FechaHora,
                 EmpleadaId = t.EmpleadaId,
                 ClienteId = t.ClienteId,
-                Realizado = t.Realizado,
+                Estado = t.Estado,
                 SucursalId = t.SucursalId,
                 SectorId = t.SectorId,
                 Detalles = t.Detalles.Select(d => new DetalleTurnoDTO

--- a/apiJMBROWS/LogicaAplicacion/CasosDeUso/CUTurno/CUObtenerTurnos.cs
+++ b/apiJMBROWS/LogicaAplicacion/CasosDeUso/CUTurno/CUObtenerTurnos.cs
@@ -3,6 +3,7 @@ using LogicaAplicacion.InterfacesCasosDeUso.ICUTurno;
 using LogicaNegocio.InterfacesRepositorio;
 using System.Collections.Generic;
 using System.Linq;
+using LogicaNegocio.Entidades.Enums;
 
 namespace LogicaAplicacion.CasosDeUso.CUTurno
 {
@@ -25,7 +26,7 @@ namespace LogicaAplicacion.CasosDeUso.CUTurno
                 ClienteId = t.ClienteId,
                 SucursalId = t.SucursalId,
                 SectorId = t.SectorId,
-                Realizado = t.Realizado,
+                Estado = t.Estado,
                 Detalles = t.Detalles.Select(d => new DetalleTurnoDTO
                 {
                     ServicioId = d.ServicioId,

--- a/apiJMBROWS/LogicaAplicacion/CasosDeUso/CUTurno/CUObtenerTurnosDelDiaPorEmpleada.cs
+++ b/apiJMBROWS/LogicaAplicacion/CasosDeUso/CUTurno/CUObtenerTurnosDelDiaPorEmpleada.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
+using LogicaNegocio.Entidades.Enums;
 namespace LogicaAplicacion.CasosDeUso.CUTurno
 {
     public class CUObtenerTurnosDelDiaPorEmpleada : ICUObtenerTurnosDelDiaPorEmpleada
@@ -26,7 +27,7 @@ namespace LogicaAplicacion.CasosDeUso.CUTurno
                 ClienteId = t.ClienteId,
                 SucursalId = t.SucursalId,
                 SectorId = t.SectorId,
-                Realizado = t.Realizado,
+                Estado = t.Estado,
                 Detalles = t.Detalles.Select(d => new DetalleTurnoDTO
                 {
                     ServicioId = d.ServicioId,

--- a/apiJMBROWS/LogicaAplicacion/CasosDeUso/CUTurno/CUObtenerTurnosPorEmpleada.cs
+++ b/apiJMBROWS/LogicaAplicacion/CasosDeUso/CUTurno/CUObtenerTurnosPorEmpleada.cs
@@ -4,6 +4,7 @@ using LogicaNegocio.InterfacesRepositorio;
 using System.Collections.Generic;
 using System.Linq;
 
+using LogicaNegocio.Entidades.Enums;
 namespace LogicaAplicacion.CasosDeUso.CUTurno
 {
     public class CUObtenerTurnosPorEmpleada : ICUObtenerTurnosPorEmpleada
@@ -25,7 +26,7 @@ namespace LogicaAplicacion.CasosDeUso.CUTurno
                 ClienteId = t.ClienteId,
                 SucursalId = t.SucursalId,
                 SectorId = t.SectorId,
-                Realizado = t.Realizado,
+                Estado = t.Estado,
                 Detalles = t.Detalles.Select(d => new DetalleTurnoDTO
                 {
                     ServicioId = d.ServicioId,

--- a/apiJMBROWS/LogicaAplicacion/Dtos/TurnoDTO/ActualizarTurnoDTO.cs
+++ b/apiJMBROWS/LogicaAplicacion/Dtos/TurnoDTO/ActualizarTurnoDTO.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using LogicaNegocio.Entidades.Enums;
 
 namespace LogicaAplicacion.Dtos.TurnoDTO
 {
@@ -9,7 +10,7 @@ namespace LogicaAplicacion.Dtos.TurnoDTO
         public DateTime FechaHora { get; set; }
         public int EmpleadaId { get; set; }
         public int ClienteId { get; set; }
-        public bool Realizado { get; set; }
+        public EstadoTurno Estado { get; set; }
         public int? SucursalId { get; set; }
         public int? SectorId { get; set; }
         public List<ActualizarDetalleTurnoDTO> Detalles { get; set; } = [];

--- a/apiJMBROWS/LogicaAplicacion/Dtos/TurnoDTO/TurnoDTO.cs
+++ b/apiJMBROWS/LogicaAplicacion/Dtos/TurnoDTO/TurnoDTO.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using LogicaNegocio.Entidades.Enums;
 
 namespace LogicaAplicacion.Dtos.TurnoDTO
 {
@@ -11,7 +12,7 @@ namespace LogicaAplicacion.Dtos.TurnoDTO
         public int ClienteId { get; set; }
         public int? SucursalId { get; set; }
         public int? SectorId { get; set; }
-        public bool Realizado { get; set; }
+        public EstadoTurno Estado { get; set; }
         public List<DetalleTurnoDTO> Detalles { get; set; } = [];
     }
 }

--- a/apiJMBROWS/LogicaNegocio/Entidades/Empleado.cs
+++ b/apiJMBROWS/LogicaNegocio/Entidades/Empleado.cs
@@ -1,5 +1,6 @@
 ﻿using LogicaNegocio.Entidades.Enums;
 using LogicaNegocio.Excepciones;
+using LogicaNegocio.Entidades.Enums;
 using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 
@@ -38,7 +39,7 @@ namespace LogicaNegocio.Entidades
         public bool EstaDisponible(DateTime inicio, DateTime fin)
         {
             // 1. Verificar solapamiento con otros turnos asignados (que no estén cancelados)
-            foreach (var turno in TurnosAsignados.Where(t => !t.Cancelado))
+            foreach (var turno in TurnosAsignados.Where(t => t.Estado != EstadoTurno.Cancelado))
             {
                 var turnoInicio = turno.FechaHora;
                 var turnoFin = turno.FechaHora.AddMinutes(turno.DuracionTotal());

--- a/apiJMBROWS/LogicaNegocio/Entidades/Enums/EstadoTurno.cs
+++ b/apiJMBROWS/LogicaNegocio/Entidades/Enums/EstadoTurno.cs
@@ -1,0 +1,9 @@
+namespace LogicaNegocio.Entidades.Enums
+{
+    public enum EstadoTurno
+    {
+        Pendiente,
+        Realizado,
+        Cancelado
+    }
+}

--- a/apiJMBROWS/LogicaNegocio/Entidades/Turno.cs
+++ b/apiJMBROWS/LogicaNegocio/Entidades/Turno.cs
@@ -1,5 +1,6 @@
-﻿using Libreria.LogicaNegocio.Entidades;
+using Libreria.LogicaNegocio.Entidades;
 using LogicaNegocio.Excepciones;
+using LogicaNegocio.Entidades.Enums;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
@@ -41,10 +42,7 @@ namespace LogicaNegocio.Entidades
 
         public List<DetalleTurno> Detalles { get; set; } = new();
 
-        public bool Realizado { get; set; } = false;
-
-        [JsonIgnore]
-        public bool Cancelado { get; set; } = false;
+        public EstadoTurno Estado { get; set; } = EstadoTurno.Pendiente;
 
         public void EsValido()
         {
@@ -93,7 +91,7 @@ namespace LogicaNegocio.Entidades
 
         public void AgregarDetalle(DetalleTurno detalle)
         {
-            if (Realizado || Cancelado)
+            if (Estado != EstadoTurno.Pendiente)
                 throw new TurnoException("No se pueden modificar los servicios de un turno realizado o cancelado.");
 
             if (Detalles.Any(d => d.ServicioId == detalle.ServicioId))
@@ -107,7 +105,7 @@ namespace LogicaNegocio.Entidades
 
         public void QuitarDetalle(int detalleId)
         {
-            if (Realizado || Cancelado)
+            if (Estado != EstadoTurno.Pendiente)
                 throw new Exception("No se pueden modificar los servicios de un turno realizado o cancelado.");
 
             var detalle = Detalles.FirstOrDefault(d => d.Id == detalleId);


### PR DESCRIPTION
## Summary
- introduce `EstadoTurno` enum to replace `Realizado`/`Cancelado`
- store new state in `Turno` entity
- adapt DTOs and use cases to use the new enum
- update queries and repositories to filter by new enum
- update EF model snapshot

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6865a84f0c2883249d0f0db9474417bb