### PR TITLE
Implementar cálculo de extras y nuevo endpoint de horarios

### DIFF
--- a/apiJMBROWS/LogicaAccesoDatos/Repositorios/RepositorioExtrasServicio.cs
+++ b/apiJMBROWS/LogicaAccesoDatos/Repositorios/RepositorioExtrasServicio.cs
@@ -36,6 +36,11 @@ namespace LogicaAccesoDatos.Repositorios
             return _context.ExtrasServicio.Where(e => e.ServicioId == servicioId).ToList();
         }
 
+        public List<ExtraServicio> ObtenerPorIds(IEnumerable<int> ids)
+        {
+            return _context.ExtrasServicio.Where(e => ids.Contains(e.Id)).ToList();
+        }
+
         public void Remove(int id)
         {
             var obj = _context.ExtrasServicio.Find(id);

--- a/apiJMBROWS/LogicaAplicacion/CasosDeUso/CUTurno/CUObtenerHorariosPorEmpleada.cs
+++ b/apiJMBROWS/LogicaAplicacion/CasosDeUso/CUTurno/CUObtenerHorariosPorEmpleada.cs
@@ -14,14 +14,17 @@ namespace LogicaAplicacion.CasosDeUso.CUTurno
         private readonly IRepositorioTurnos _repoTurno;
         private readonly IRepositorioUsuarios _repoEmpleado;
         private readonly IRepositorioServicios _repoServicio;
+        private readonly IRepositorioExtrasServicio _repoExtras;
 
         public CUObtenerHorariosPorEmpleada(IRepositorioTurnos repoTurno,
                                              IRepositorioUsuarios repoEmpleado,
-                                             IRepositorioServicios repoServicio)
+                                             IRepositorioServicios repoServicio,
+                                             IRepositorioExtrasServicio repoExtras)
         {
             _repoTurno = repoTurno;
             _repoEmpleado = repoEmpleado;
             _repoServicio = repoServicio;
+            _repoExtras = repoExtras;
         }
 
         public List<HorarioDisponibleDTO> Ejecutar(HorariosPorEmpleadaFiltroDTO filtro)
@@ -31,7 +34,10 @@ namespace LogicaAplicacion.CasosDeUso.CUTurno
                 return new List<HorarioDisponibleDTO>();
 
             var servicios = _repoServicio.ObtenerPorIds(filtro.ServicioIds);
-            int duracionTotal = servicios.Sum(s => s.DuracionMinutos);
+            var extras = filtro.ExtraIds != null && filtro.ExtraIds.Any()
+                ? _repoExtras.ObtenerPorIds(filtro.ExtraIds)
+                : new List<ExtraServicio>();
+            int duracionTotal = servicios.Sum(s => s.DuracionMinutos) + extras.Sum(e => e.DuracionMinutos);
 
             var habilidadesNecesarias = servicios
                 .SelectMany(s => s.Habilidades)

--- a/apiJMBROWS/LogicaAplicacion/Dtos/TurnoDTO/HorarioOcupadoDTO.cs
+++ b/apiJMBROWS/LogicaAplicacion/Dtos/TurnoDTO/HorarioOcupadoDTO.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace LogicaAplicacion.Dtos.TurnoDTO
+{
+    public class HorarioOcupadoDTO
+    {
+        public DateTime FechaHoraInicio { get; set; }
+        public DateTime FechaHoraFin { get; set; }
+    }
+}

--- a/apiJMBROWS/LogicaAplicacion/Dtos/TurnoDTO/HorariosDisponiblesFiltroDTO.cs
+++ b/apiJMBROWS/LogicaAplicacion/Dtos/TurnoDTO/HorariosDisponiblesFiltroDTO.cs
@@ -11,5 +11,6 @@ namespace LogicaAplicacion.Dtos.TurnoDTO
         public int SucursalId { get; set; }
         public DateTime Fecha { get; set; }
         public List<int> ServicioIds { get; set; } = new();
+        public List<int>? ExtraIds { get; set; }
     }
 }

--- a/apiJMBROWS/LogicaAplicacion/Dtos/TurnoDTO/HorariosPorEmpleadaFiltroDTO.cs
+++ b/apiJMBROWS/LogicaAplicacion/Dtos/TurnoDTO/HorariosPorEmpleadaFiltroDTO.cs
@@ -9,5 +9,6 @@ namespace LogicaAplicacion.Dtos.TurnoDTO
         public int SucursalId { get; set; }
         public DateTime Fecha { get; set; }
         public List<int> ServicioIds { get; set; } = new();
+        public List<int>? ExtraIds { get; set; }
     }
 }

--- a/apiJMBROWS/LogicaAplicacion/InterfacesCasosDeUso/ICUTurno/ICUObtenerHorariosOcupados.cs
+++ b/apiJMBROWS/LogicaAplicacion/InterfacesCasosDeUso/ICUTurno/ICUObtenerHorariosOcupados.cs
@@ -1,0 +1,10 @@
+using LogicaAplicacion.Dtos.TurnoDTO;
+using System.Collections.Generic;
+
+namespace LogicaAplicacion.InterfacesCasosDeUso.ICUTurno
+{
+    public interface ICUObtenerHorariosOcupados
+    {
+        List<HorarioOcupadoDTO> Ejecutar(HorariosDisponiblesFiltroDTO filtro);
+    }
+}

--- a/apiJMBROWS/LogicaNegocio/InterfacesRepositorio/IRepositorioExtrasServicio.cs
+++ b/apiJMBROWS/LogicaNegocio/InterfacesRepositorio/IRepositorioExtrasServicio.cs
@@ -6,5 +6,6 @@ namespace LogicaNegocio.InterfacesRepositorio
     public interface IRepositorioExtrasServicio : IRepositorio<ExtraServicio>
     {
         IEnumerable<ExtraServicio> ObtenerPorServicio(int servicioId);
+        List<ExtraServicio> ObtenerPorIds(IEnumerable<int> ids);
     }
 }

--- a/apiJMBROWS/apiJMBROWS/Controllers/TurnoController.cs
+++ b/apiJMBROWS/apiJMBROWS/Controllers/TurnoController.cs
@@ -28,6 +28,7 @@ namespace apiJMBROWS.Controllers
         private readonly ICUEliminarDetalleTurno _eliminarDetalleTurno;
         private readonly ICUObtenerHorariosDisponibles _horariosDisponibles;
         private readonly ICUObtenerHorariosPorEmpleada _horariosPorEmpleada;
+        private readonly ICUObtenerHorariosOcupados _horariosOcupados;
         public TurnosController(
             ICUAltaTurno altaTurno,
             ICUObtenerTurnos obtenerTurnos,
@@ -42,7 +43,8 @@ namespace apiJMBROWS.Controllers
             ICUObtenerDetalleTurnoPorId obtenerDetalleTurnoPorId,
             ICUEliminarDetalleTurno eliminarDetalleTurno,
             ICUObtenerHorariosDisponibles horariosDisponibles,
-            ICUObtenerHorariosPorEmpleada horariosPorEmpleada
+            ICUObtenerHorariosPorEmpleada horariosPorEmpleada,
+            ICUObtenerHorariosOcupados horariosOcupados
             )
         {
             _altaTurno = altaTurno;
@@ -59,6 +61,7 @@ namespace apiJMBROWS.Controllers
             _eliminarDetalleTurno = eliminarDetalleTurno;
             _horariosDisponibles = horariosDisponibles;
             _horariosPorEmpleada = horariosPorEmpleada;
+            _horariosOcupados = horariosOcupados;
         }
 
         /// <summary>
@@ -303,6 +306,28 @@ namespace apiJMBROWS.Controllers
                     return BadRequest("Debe seleccionar al menos un servicio.");
 
                 var horarios = _horariosPorEmpleada.Ejecutar(filtro);
+                return Ok(horarios);
+            }
+            catch (Exception ex)
+            {
+                return StatusCode(500, $"Error al obtener horarios: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Obtiene las franjas horarias sin disponibilidad
+        /// </summary>
+        [HttpPost("horarios-ocupados")]
+        [AllowAnonymous]
+        [SwaggerOperation(Summary = "Horarios sin disponibilidad para la fecha seleccionada")]
+        public ActionResult<List<HorarioOcupadoDTO>> ObtenerHorariosOcupados([FromBody] HorariosDisponiblesFiltroDTO filtro)
+        {
+            try
+            {
+                if (filtro.ServicioIds == null || !filtro.ServicioIds.Any())
+                    return BadRequest("Debe seleccionar al menos un servicio.");
+
+                var horarios = _horariosOcupados.Ejecutar(filtro);
                 return Ok(horarios);
             }
             catch (Exception ex)

--- a/apiJMBROWS/apiJMBROWS/Program.cs
+++ b/apiJMBROWS/apiJMBROWS/Program.cs
@@ -128,6 +128,7 @@ namespace apiJMBROWS
             builder.Services.AddScoped<ICUObtenerTurnosDelDiaPorEmpleada, CUObtenerTurnosDelDiaPorEmpleada>();
             builder.Services.AddScoped<ICUObtenerHorariosDisponibles, CUObtenerHorariosDisponibles>();
             builder.Services.AddScoped<ICUObtenerHorariosPorEmpleada, CUObtenerHorariosPorEmpleada>();
+            builder.Services.AddScoped<ICUObtenerHorariosOcupados, CUObtenerHorariosOcupados>();
 
             builder.Services.AddScoped<ICUAltaDetalleTurno, CUAltaDetalleTurno>();
             builder.Services.AddScoped<ICUActualizarDetalleTurno, CUActualizarDetalleTurno>();


### PR DESCRIPTION
## Summary
- soportar extras en filtros de horarios
- exponer método `ObtenerPorIds` en repositorio de extras
- considerar extras en `CUObtenerHorariosDisponibles` y `CUObtenerHorariosPorEmpleada`
- crear `CUObtenerHorariosOcupados` y su interfaz
- añadir DTO `HorarioOcupadoDTO`
- exponer nuevo endpoint `horarios-ocupados`
- registrar caso de uso en `Program`
