### PR TITLE
Ensure UTC usage across backend

### DIFF
--- a/apiJMBROWS/LogicaAplicacion/CasosDeUso/CUTurno/CUMarcarTurnoComoRealizado.cs
+++ b/apiJMBROWS/LogicaAplicacion/CasosDeUso/CUTurno/CUMarcarTurnoComoRealizado.cs
@@ -38,7 +38,7 @@ namespace LogicaAplicacion.CasosDeUso.CUTurno
                 throw new Exception("No se puede marcar como realizado un turno cancelado.");
 
             turno.Estado = EstadoTurno.Realizado;
-            _repo.Update(turnoId, turno); _logger.LogInformation("Turno {Id} confirmado a las {Fecha}", turnoId, DateTime.UtcNow);
+            _repo.Update(turnoId, turno); _logger.LogInformation("Turno {Id} confirmado a las {Fecha}", turnoId, DateTimeOffset.UtcNow);
         }
     }
 }

--- a/apiJMBROWS/LogicaAplicacion/CasosDeUso/CUTurno/CUObtenerTurnosFiltrados.cs
+++ b/apiJMBROWS/LogicaAplicacion/CasosDeUso/CUTurno/CUObtenerTurnosFiltrados.cs
@@ -22,7 +22,7 @@ namespace LogicaAplicacion.CasosDeUso.CUTurno
             // Si no se especifica rango de fechas, tomar el día actual
             if (!filtro.FechaInicio.HasValue && !filtro.FechaFin.HasValue)
             {
-                var hoy = DateTime.Today;
+                var hoy = DateTimeOffset.UtcNow.Date;
                 filtro.FechaInicio = hoy;
                 filtro.FechaFin = hoy.AddDays(1).AddTicks(-1);
             }

--- a/apiJMBROWS/LogicaNegocio/Entidades/Notificacion.cs
+++ b/apiJMBROWS/LogicaNegocio/Entidades/Notificacion.cs
@@ -23,7 +23,7 @@ namespace LogicaNegocio.Entidades
         [Required]
         public required string Mensaje { get; set; }
 
-        public DateTimeOffset FechaEnvio { get; set; } = DateTime.UtcNow;
+        public DateTimeOffset FechaEnvio { get; set; } = DateTimeOffset.UtcNow;
 
         public bool Enviada { get; set; } = false;
 

--- a/apiJMBROWS/apiJMBROWS/Controllers/EmpleadoController.cs
+++ b/apiJMBROWS/apiJMBROWS/Controllers/EmpleadoController.cs
@@ -13,6 +13,7 @@ using LogicaAplicacion.InterfacesCasosDeUso.ICUTurno;
 using LogicaNegocio.Entidades;
 using LogicaNegocio.Excepciones;
 using LogicaNegocio.InterfacesRepositorio;
+using apiJMBROWS.Utils;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
@@ -40,6 +41,7 @@ namespace apiJMBROWS.Controllers
         private readonly ICUObtenerEmpleadoPorHabilidad _obtenerEmpleadoPorHabilidad;
         private readonly ICUObtenerTurnosDelDiaPorEmpleada _cuObtenerTurnosDelDia;
         private readonly ICUObtenerEmpleadasPorSector _obtenerEmpleadasPorSector;
+        private readonly ITimeProvider _timeProvider;
         public EmpleadoController(
             ICUAltaEmpleado altaEmpleado,
             ICUObtenerEmpleados obtenerEmpleados,
@@ -56,7 +58,8 @@ namespace apiJMBROWS.Controllers
             ICUObtenerEmpleadasDisponibles obtenerDisponibles,
             ICUObtenerEmpleadoPorHabilidad obtenerEmpleadoPorHabilidad,
             ICUObtenerTurnosDelDiaPorEmpleada ObtenerTurnosDelDia,
-            ICUObtenerEmpleadasPorSector obtenerEmpleadasPorSector)
+            ICUObtenerEmpleadasPorSector obtenerEmpleadasPorSector,
+            ITimeProvider timeProvider)
         {
             _altaEmpleado = altaEmpleado;
             _obtenerEmpleados = obtenerEmpleados;
@@ -74,6 +77,7 @@ namespace apiJMBROWS.Controllers
             _obtenerEmpleadoPorHabilidad = obtenerEmpleadoPorHabilidad;
             _cuObtenerTurnosDelDia = ObtenerTurnosDelDia;
             _obtenerEmpleadasPorSector = obtenerEmpleadasPorSector;
+            _timeProvider = timeProvider;
 
         }
 
@@ -351,7 +355,8 @@ namespace apiJMBROWS.Controllers
         {
             try
             {
-                var turnos = _cuObtenerTurnosDelDia.Ejecutar(empleadoId, DateTime.Today);
+                var fecha = _timeProvider.UtcNow.Date;
+                var turnos = _cuObtenerTurnosDelDia.Ejecutar(empleadoId, fecha);
                 return Ok(turnos);
             }
             catch (Exception ex)

--- a/apiJMBROWS/apiJMBROWS/Controllers/TurnoController.cs
+++ b/apiJMBROWS/apiJMBROWS/Controllers/TurnoController.cs
@@ -5,6 +5,7 @@ using LogicaAplicacion.InterfacesCasosDeUso.ICUDetalleTurno;
 using LogicaAplicacion.InterfacesCasosDeUso.ICUEmpleado;
 using LogicaAplicacion.InterfacesCasosDeUso.ICUTurno;
 using LogicaNegocio.Entidades.Enums;
+using apiJMBROWS.Utils;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
@@ -33,6 +34,7 @@ namespace apiJMBROWS.Controllers
         private readonly ICUObtenerHorariosOcupados _horariosOcupados;
         private readonly ICUMarcarTurnoComoRealizado _marcarTurnoComoRealizado;
         private readonly ICUObtenerTurnosFiltrados _obtenerTurnosFiltrados;
+        private readonly ITimeProvider _timeProvider;
         public TurnosController(
             ICUAltaTurno altaTurno,
             ICUObtenerTurnos obtenerTurnos,
@@ -50,7 +52,8 @@ namespace apiJMBROWS.Controllers
             ICUObtenerHorariosPorEmpleada horariosPorEmpleada,
             ICUObtenerHorariosOcupados horariosOcupados,
             ICUMarcarTurnoComoRealizado marcarTurnoComoRealizado,
-            ICUObtenerTurnosFiltrados obtenerTurnosFiltrados
+            ICUObtenerTurnosFiltrados obtenerTurnosFiltrados,
+            ITimeProvider timeProvider
             )
         {
             _altaTurno = altaTurno;
@@ -70,6 +73,7 @@ namespace apiJMBROWS.Controllers
             _horariosOcupados = horariosOcupados;
             _marcarTurnoComoRealizado = marcarTurnoComoRealizado;
             _obtenerTurnosFiltrados = obtenerTurnosFiltrados;
+            _timeProvider = timeProvider;
         }
 
         /// <summary>
@@ -247,7 +251,8 @@ namespace apiJMBROWS.Controllers
         [SwaggerResponse(200, "Lista de turnos de hoy", typeof(IEnumerable<TurnoDTO>))]
         public IActionResult TurnosHoy(int empleadaId)
         {
-            var lista = _obtenerTurnosDelDiaPorEmpleada.Ejecutar(empleadaId, DateTimeOffset.UtcNow.Date);
+            var fecha = _timeProvider.UtcNow.Date;
+            var lista = _obtenerTurnosDelDiaPorEmpleada.Ejecutar(empleadaId, fecha);
             return Ok(lista);
         }
 

--- a/apiJMBROWS/apiJMBROWS/Controllers/UsuarioController.cs
+++ b/apiJMBROWS/apiJMBROWS/Controllers/UsuarioController.cs
@@ -55,7 +55,7 @@ namespace apiJMBROWS.Controllers
                     token,
                     email = admin.Email,
                     rol = admin.Rol,
-                    expires = DateTime.UtcNow.AddHours(2)
+                    expires = DateTimeOffset.UtcNow.AddHours(2)
                 });
             }
             catch (UsuarioException ex)

--- a/apiJMBROWS/apiJMBROWS/Program.cs
+++ b/apiJMBROWS/apiJMBROWS/Program.cs
@@ -54,6 +54,9 @@ namespace apiJMBROWS
                 options.JsonSerializerOptions.Converters.Add(new UtcDateTimeOffsetConverter());
              });
 
+            // Servicio de tiempo centralizado
+            builder.Services.AddSingleton<ITimeProvider, SystemTimeProvider>();
+
             // Repositorios
             builder.Services.AddScoped<IRepositorioUsuarios, RepositorioUsuarios>();
             builder.Services.AddScoped<IRepositorioSucursales, RepositorioSucursales>();

--- a/apiJMBROWS/apiJMBROWS/Utils/ITimeProvider.cs
+++ b/apiJMBROWS/apiJMBROWS/Utils/ITimeProvider.cs
@@ -1,0 +1,13 @@
+namespace apiJMBROWS.Utils
+{
+    /// <summary>
+    /// Provee la hora actual en UTC para centralizar el manejo de tiempo.
+    /// </summary>
+    public interface ITimeProvider
+    {
+        /// <summary>
+        /// Obtiene la fecha y hora actuales en UTC.
+        /// </summary>
+        DateTimeOffset UtcNow { get; }
+    }
+}

--- a/apiJMBROWS/apiJMBROWS/Utils/SystemTimeProvider.cs
+++ b/apiJMBROWS/apiJMBROWS/Utils/SystemTimeProvider.cs
@@ -1,0 +1,11 @@
+namespace apiJMBROWS.Utils
+{
+    /// <summary>
+    /// Implementación de <see cref="ITimeProvider"/> que utiliza
+    /// <see cref="DateTimeOffset.UtcNow"/>.
+    /// </summary>
+    public class SystemTimeProvider : ITimeProvider
+    {
+        public DateTimeOffset UtcNow => DateTimeOffset.UtcNow;
+    }
+}


### PR DESCRIPTION
## Summary
- add `ITimeProvider` and `SystemTimeProvider` to centralize current time
- register the time provider in `Program.cs`
- inject and use the provider in `EmpleadoController` and `TurnoController`
- replace `DateTime.Today` logic with `DateTimeOffset.UtcNow` in turnos filtering
- switch various remaining usages to `DateTimeOffset.UtcNow`

